### PR TITLE
check is something is a dir by looking for an extension

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -56,7 +56,7 @@ impl Route {
 
     pub fn write(&self, out: &Path) -> Result {
         // If a directory is passed in, append the filename before continuing
-        let out = if out.is_dir() {
+        let out = if out.extension().is_none() {
             out.join(self.filename())
         } else {
             out.into()


### PR DESCRIPTION
is_dir checks if a directory exists, not if the input is meant to be interpreted as a directory.