### PR TITLE
setting signature field from signing keypair

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -334,7 +334,7 @@ fn generate_route(args: GenerateRoute) -> Result<Msg> {
 async fn get_routes(args: GetRoutes) -> Result<Msg> {
     let mut client = client::RouteClient::new(&args.config_host).await?;
     let route_list = client
-        .list(args.oui, &args.owner, &args.keypair.to_keypair()?)
+        .list(args.oui, &args.keypair.to_keypair()?)
         .await?;
 
     if args.commit {
@@ -348,7 +348,7 @@ async fn get_routes(args: GetRoutes) -> Result<Msg> {
 async fn get_route(args: GetRoute) -> Result<Msg> {
     let mut client = client::RouteClient::new(&args.config_host).await?;
     let route = client
-        .get(&args.route_id, &args.owner, &args.keypair.to_keypair()?)
+        .get(&args.route_id, &args.keypair.to_keypair()?)
         .await?;
 
     if args.commit {
@@ -386,7 +386,7 @@ async fn create_route(args: CreateRoute) -> Result<Msg> {
     if args.commit {
         let mut client = client::RouteClient::new(&args.config_host).await?;
         match client
-            .create_route(route, &args.owner, &args.keypair.to_keypair()?)
+            .create_route(route, &args.keypair.to_keypair()?)
             .await
         {
             Ok(created_route) => {
@@ -418,7 +418,7 @@ async fn update_route(args: UpdateRoute) -> Result<Msg> {
     if args.commit {
         let mut client = client::RouteClient::new(&args.config_host).await?;
         let updated_route = client
-            .push(route, &args.owner, &args.keypair.to_keypair()?)
+            .push(route, &args.keypair.to_keypair()?)
             .await?;
         updated_route.write(args.route_file.as_path())?;
         return Msg::ok(format!("{} written", &args.route_file.display()));
@@ -434,7 +434,7 @@ async fn remove_route(args: RemoveRoute) -> Result<Msg> {
     if args.commit {
         let mut client = client::RouteClient::new(&args.config_host).await?;
         let removed_route = client
-            .delete(&route.id, &args.owner, &args.keypair.to_keypair()?)
+            .delete(&route.id, &args.keypair.to_keypair()?)
             .await?;
         removed_route.remove(
             args.route_file

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,7 @@ impl OrgClient {
             payer: payer.into(),
             devaddrs: devaddr_count,
             timestamp: current_timestamp()?,
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             signature: vec![],
         };
         request.signature = request.sign(&keypair)?;
@@ -70,7 +70,7 @@ impl OrgClient {
             payer: payer.into(),
             net_id,
             timestamp: current_timestamp()?,
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             signature: vec![],
         };
         request.signature = request.sign(&keypair)?;
@@ -93,12 +93,11 @@ impl RouteClient {
     pub async fn list(
         &mut self,
         oui: u64,
-        owner: &PublicKey,
         keypair: &Keypair,
     ) -> Result<RouteList> {
         let mut request = RouteListReqV1 {
             oui,
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             timestamp: current_timestamp()?,
             signature: vec![],
         };
@@ -106,10 +105,10 @@ impl RouteClient {
         Ok(self.client.list(request).await?.into_inner().into())
     }
 
-    pub async fn get(&mut self, id: &str, owner: &PublicKey, keypair: &Keypair) -> Result<Route> {
+    pub async fn get(&mut self, id: &str, keypair: &Keypair) -> Result<Route> {
         let mut request = RouteGetReqV1 {
             id: id.into(),
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             signature: vec![],
             timestamp: current_timestamp()?,
         };
@@ -122,13 +121,12 @@ impl RouteClient {
         net_id: hex_field::HexNetID,
         oui: u64,
         max_copies: u32,
-        owner: &PublicKey,
         keypair: &Keypair,
     ) -> Result<Route> {
         let mut request = RouteCreateReqV1 {
             oui,
             route: Some(Route::new(net_id, oui, max_copies).into()),
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             timestamp: current_timestamp()?,
             signature: vec![],
         };
@@ -139,13 +137,12 @@ impl RouteClient {
     pub async fn create_route(
         &mut self,
         route: Route,
-        owner: &PublicKey,
         keypair: &Keypair,
     ) -> Result<Route> {
         let mut request = RouteCreateReqV1 {
             oui: route.oui,
             route: Some(route.into()),
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             timestamp: current_timestamp()?,
             signature: vec![],
         };
@@ -156,12 +153,11 @@ impl RouteClient {
     pub async fn delete(
         &mut self,
         id: &str,
-        owner: &PublicKey,
         keypair: &Keypair,
     ) -> Result<Route> {
         let mut request = RouteDeleteReqV1 {
             id: id.into(),
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             timestamp: current_timestamp()?,
             signature: vec![],
         };
@@ -172,12 +168,11 @@ impl RouteClient {
     pub async fn push(
         &mut self,
         route: Route,
-        owner: &PublicKey,
         keypair: &Keypair,
     ) -> Result<Route> {
         let mut request = RouteUpdateReqV1 {
             route: Some(route.into()),
-            signer: owner.into(),
+            signer: keypair.public_key().into(),
             timestamp: current_timestamp()?,
             signature: vec![],
         };

--- a/src/cmds.rs
+++ b/src/cmds.rs
@@ -242,8 +242,6 @@ pub struct GenerateRoute {
 pub struct GetRoutes {
     #[arg(long, env = ENV_OUI)]
     pub oui: u64,
-    #[arg(short, long)]
-    pub owner: PublicKey,
     #[arg(from_global)]
     pub keypair: PathBuf,
     // #[arg(long, default_value = "./routes")]
@@ -263,8 +261,6 @@ pub struct GetRoutes {
 pub struct GetRoute {
     #[arg(short, long)]
     pub route_id: String,
-    #[arg(short, long)]
-    pub owner: PublicKey,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(long, default_value = "./routes")]
@@ -293,8 +289,6 @@ pub struct GetOrg {
 pub struct CreateRoute {
     #[arg(long, default_value = "./new_route.json")]
     pub route_file: PathBuf,
-    #[arg(long)]
-    pub owner: PublicKey,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]
@@ -309,8 +303,6 @@ pub struct CreateRoute {
 pub struct UpdateRoute {
     #[arg(long)]
     pub route_file: PathBuf,
-    #[arg(long)]
-    pub owner: PublicKey,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]
@@ -323,8 +315,6 @@ pub struct UpdateRoute {
 pub struct RemoveRoute {
     #[arg(long)]
     pub route_file: PathBuf,
-    #[arg(long)]
-    pub owner: PublicKey,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]


### PR DESCRIPTION
disambiguate the binary public key setting in a request `signature` field from the `owner` as certain situations can exist where the signing keypair is _not_ the owner of the org being created or of the routes under that org (admin keypair creating organizations and delegate keys creating routes on behalf of an org's owner)