### PR TITLE
adding region params loading to the cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#8815569df5b56cd93f4fcd0b4e0582de4ae71d92"
+source = "git+https://github.com/helium/proto?branch=master#1a809cce9d07ba32b75bfb5cda05c4a9fdef34e8"
 dependencies = [
  "bytes",
  "prost",

--- a/src/cmds/env.rs
+++ b/src/cmds/env.rs
@@ -3,7 +3,7 @@ use std::{env, fs, path::PathBuf};
 use super::{
     EnvInfo, GenerateKeypair, ENV_CONFIG_HOST, ENV_KEYPAIR_BIN, ENV_MAX_COPIES, ENV_NET_ID, ENV_OUI,
 };
-use crate::{hex_field, Msg, PrettyJson, Result, OUI};
+use crate::{hex_field, Msg, Oui, PrettyJson, Result};
 use anyhow::Context;
 use dialoguer::Input;
 use helium_crypto::Keypair;
@@ -27,7 +27,7 @@ pub async fn env_init() -> Result<Msg> {
         .with_initial_text("000000")
         .interact()?;
     println!("----- Enter zero to ignore...");
-    let oui: OUI = Input::new()
+    let oui: Oui = Input::new()
         .with_prompt("Assigned OUI")
         .with_initial_text("0")
         .allow_empty(true)

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -71,7 +71,7 @@ pub enum Commands {
     },
     /// Print a Subnet Mask for a given Devaddr Range
     SubnetMask(SubnetMask),
-    //. Region Params
+    /// Region Params
     RegionParams {
         #[command(subcommand)]
         command: RegionParamsCommands,

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     hex_field::{self, HexNetID},
     region::Region,
-    DevaddrConstraint, Msg, PrettyJson, Result, OUI,
+    DevaddrConstraint, Msg, Oui, PrettyJson, Result,
 };
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 pub mod env;
 pub mod org;
+pub mod region_params;
 pub mod route;
 pub mod session_key_filter;
 
@@ -64,12 +65,17 @@ pub enum Commands {
     },
     /// Session Key Filter
     #[command(alias = "skf")]
-    SessionKeyFiler {
+    SessionKeyFilter {
         #[command(subcommand)]
         command: SessionKeyFilterCommands,
     },
     /// Print a Subnet Mask for a given Devaddr Range
     SubnetMask(SubnetMask),
+    //. Region Params
+    RegionParams {
+        #[command(subcommand)]
+        command: RegionParamsCommands,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -112,7 +118,7 @@ pub enum RouteCommands {
 #[derive(Debug, Args)]
 pub struct ListRoutes {
     #[arg(long, env = ENV_OUI)]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]
@@ -136,7 +142,7 @@ pub struct NewRoute {
     #[arg(long, env = ENV_NET_ID, default_value = "C00053")]
     pub net_id: HexNetID,
     #[arg(long, env = ENV_OUI)]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(long, env = ENV_MAX_COPIES, default_value = "5")]
     pub max_copies: u32,
 
@@ -324,7 +330,7 @@ pub enum SessionKeyFilterCommands {
 #[derive(Debug, Args)]
 pub struct ListFilters {
     #[arg(long, env = ENV_OUI)]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]
@@ -334,7 +340,7 @@ pub struct ListFilters {
 #[derive(Debug, Args)]
 pub struct GetFilters {
     #[arg(long, env = ENV_OUI)]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(short, long, value_parser = hex_field::validate_devaddr)]
     pub devaddr: hex_field::HexDevAddr,
     #[arg(from_global)]
@@ -346,7 +352,7 @@ pub struct GetFilters {
 #[derive(Debug, Args)]
 pub struct AddFilter {
     #[arg(long, env = ENV_OUI)]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(short, long, value_parser = hex_field::validate_devaddr)]
     pub devaddr: hex_field::HexDevAddr,
     #[arg(short, long)]
@@ -363,7 +369,7 @@ pub struct AddFilter {
 #[derive(Debug, Args)]
 pub struct RemoveFilter {
     #[arg(long, env = ENV_OUI)]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(short, long, value_parser = hex_field::validate_devaddr)]
     pub devaddr: hex_field::HexDevAddr,
     #[arg(short, long)]
@@ -518,7 +524,7 @@ pub struct EnvInfo {
     #[arg(long, env = ENV_NET_ID)]
     pub net_id: Option<HexNetID>,
     #[arg(long, env = ENV_OUI)]
-    pub oui: Option<OUI>,
+    pub oui: Option<Oui>,
     #[arg(long, env = ENV_MAX_COPIES)]
     pub max_copies: Option<u32>,
 }
@@ -542,7 +548,7 @@ pub struct ListOrgs {
 #[derive(Debug, Args)]
 pub struct GetOrg {
     #[arg(long, env = "HELIUM_OUI")]
-    pub oui: OUI,
+    pub oui: Oui,
     #[arg(from_global)]
     pub config_host: String,
 }
@@ -571,6 +577,28 @@ pub struct CreateRoaming {
     pub payer: PublicKey,
     #[arg(long)]
     pub net_id: HexNetID,
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(long)]
+    pub commit: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RegionParamsCommands {
+    /// Push a region params collection to the config service
+    Push(PushRegionParams),
+}
+
+#[derive(Debug, Args)]
+pub struct PushRegionParams {
+    #[arg(value_enum)]
+    pub region: Region,
+    #[arg(long)]
+    pub params_file: PathBuf,
+    #[arg(long)]
+    pub index_file: Option<PathBuf>,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]

--- a/src/cmds/region_params.rs
+++ b/src/cmds/region_params.rs
@@ -1,0 +1,48 @@
+use crate::{client, cmds::PathBufKeypair, region_params::RegionParams, Msg, PrettyJson, Result};
+use anyhow::Context;
+use helium_proto::Region as ProtoRegion;
+use std::{
+    fs::{self, File},
+    io::Read,
+};
+
+use super::PushRegionParams;
+
+pub async fn push_params(args: PushRegionParams) -> Result<Msg> {
+    let mut client = client::GatewayClient::new(&args.config_host).await?;
+    let params = RegionParams::from_file(&args.params_file)?;
+
+    let index_bytes = if let Some(index_path) = &args.index_file {
+        let mut index_file = File::open(index_path).context("reading region h3 indices file")?;
+        let metadata = fs::metadata(index_path).context("reading index file metadata")?;
+        let mut byte_buf = vec![0; metadata.len() as usize];
+        index_file
+            .read(&mut byte_buf)
+            .context("reading index buffer")?;
+
+        Some(byte_buf)
+    } else {
+        None
+    };
+
+    if !args.commit {
+        return Msg::dry_run(params.pretty_json()?);
+    }
+
+    match client
+        .load_region(
+            args.region.clone(),
+            params.clone(),
+            index_bytes,
+            &args.keypair.to_keypair()?,
+        )
+        .await
+    {
+        Ok(_) => Msg::ok(format!(
+            "created region params {}\n{}",
+            ProtoRegion::from(args.region),
+            params.pretty_json()?
+        )),
+        Err(err) => Msg::err(format!("region params not created: {err}")),
+    }
+}

--- a/src/hex_field.rs
+++ b/src/hex_field.rs
@@ -78,7 +78,7 @@ impl<'de, const WIDTH: usize> Deserialize<'de> for HexField<WIDTH> {
             type Value = HexField<IN_WIDTH>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str(&format!("hex string {} wide", IN_WIDTH))
+                formatter.write_str(&format!("hex string {IN_WIDTH} wide"))
             }
 
             fn visit_str<E>(self, value: &str) -> anyhow::Result<HexField<IN_WIDTH>, E>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod cmds;
 pub mod hex_field;
 pub mod region;
+pub mod region_params;
 pub mod route;
 pub mod server;
 pub mod subnet;
@@ -22,7 +23,7 @@ pub mod proto {
 
 pub type Result<T = (), E = Error> = anyhow::Result<T, E>;
 
-type OUI = u64;
+type Oui = u64;
 
 #[derive(Debug, Serialize)]
 pub enum Msg {
@@ -53,9 +54,9 @@ impl Msg {
 impl Display for Msg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Msg::DryRun(msg) => write!(f, "== DRY RUN == (pass `--commit`)\n{}", msg),
-            Msg::Success(msg) => write!(f, "\u{2713} {}", msg),
-            Msg::Error(msg) => write!(f, "\u{2717} {}", msg),
+            Msg::DryRun(msg) => write!(f, "== DRY RUN == (pass `--commit`)\n{msg}"),
+            Msg::Success(msg) => write!(f, "\u{2713} {msg}"),
+            Msg::Error(msg) => write!(f, "\u{2717} {msg}"),
         }
     }
 }
@@ -104,7 +105,7 @@ pub struct OrgList {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Org {
-    pub oui: OUI,
+    pub oui: Oui,
     pub owner: PublicKey,
     pub payer: PublicKey,
     pub delegate_keys: Vec<PublicKey>,
@@ -163,13 +164,13 @@ impl Eui {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct SessionKeyFilter {
-    pub oui: OUI,
+    pub oui: Oui,
     pub devaddr: hex_field::HexDevAddr,
     pub session_key: String,
 }
 
 impl SessionKeyFilter {
-    pub fn new(oui: OUI, devaddr: hex_field::HexDevAddr, session_key: String) -> Self {
+    pub fn new(oui: Oui, devaddr: hex_field::HexDevAddr, session_key: String) -> Self {
         Self {
             oui,
             devaddr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 use helium_config_service_cli::{
     cmds::{
-        self, env, org,
+        self, env, org, region_params,
         route::{self, devaddrs, euis},
         session_key_filter as skf, Cli, Commands, EnvCommands as Env, OrgCommands as Org,
-        RouteCommands, RouteUpdateCommand,
+        RegionParamsCommands, RouteCommands, RouteUpdateCommand,
     },
     Msg, Result,
 };
@@ -59,12 +59,15 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
             Org::CreateHelium(args) => org::create_helium_org(args).await,
             Org::CreateRoaming(args) => org::create_roaming_org(args).await,
         },
-        Commands::SessionKeyFiler { command } => match command {
+        Commands::SessionKeyFilter { command } => match command {
             cmds::SessionKeyFilterCommands::List(args) => skf::list_filters(args).await,
             cmds::SessionKeyFilterCommands::Get(args) => skf::get_filters(args).await,
             cmds::SessionKeyFilterCommands::Add(args) => skf::add_filter(args).await,
             cmds::SessionKeyFilterCommands::Remove(args) => skf::remove_filter(args).await,
         },
         Commands::SubnetMask(args) => cmds::subnet_mask(args),
+        Commands::RegionParams { command } => match command {
+            RegionParamsCommands::Push(args) => region_params::push_params(args).await,
+        },
     }
 }

--- a/src/region_params.rs
+++ b/src/region_params.rs
@@ -1,0 +1,223 @@
+use crate::Result;
+use anyhow::{anyhow, Context};
+use serde::{de, Deserialize, Deserializer, Serialize};
+use std::{fmt, fs, path::PathBuf, str::FromStr};
+
+pub mod proto {
+    pub use helium_proto::{
+        BlockchainRegionParamV1, BlockchainRegionParamsV1, BlockchainRegionSpreadingV1,
+        RegionSpreading, TaggedSpreading,
+    };
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RegionParams {
+    pub region_params: Vec<RegionParam>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RegionParam {
+    pub channel_frequency: u64,
+    pub bandwidth: u32,
+    pub max_eirp: u32,
+    pub spreading: BlockchainRegionSpreading,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BlockchainRegionSpreading {
+    pub tagged_spreading: Vec<TaggedSpreading>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaggedSpreading {
+    pub region_spreading: RegionSpreading,
+    pub max_packet_size: u32,
+}
+
+#[derive(Clone, Debug)]
+pub enum RegionSpreading {
+    SfInvalid,
+    Sf7,
+    Sf8,
+    Sf9,
+    Sf10,
+    Sf11,
+    Sf12,
+}
+
+impl RegionParams {
+    pub fn from_file(path: &PathBuf) -> Result<Self> {
+        let data = fs::read_to_string(path).context("reading params file")?;
+        let listing: Self = serde_json::from_str(&data)
+            .context(format!("parsing params file {}", path.display()))?;
+        Ok(listing)
+    }
+}
+
+impl From<RegionParams> for proto::BlockchainRegionParamsV1 {
+    fn from(rp: RegionParams) -> Self {
+        Self {
+            region_params: rp.region_params.into_iter().map(|r| r.into()).collect(),
+        }
+    }
+}
+
+impl From<proto::BlockchainRegionParamsV1> for RegionParams {
+    fn from(brp: proto::BlockchainRegionParamsV1) -> Self {
+        Self {
+            region_params: brp.region_params.into_iter().map(|r| r.into()).collect(),
+        }
+    }
+}
+
+impl From<RegionParam> for proto::BlockchainRegionParamV1 {
+    fn from(rp: RegionParam) -> Self {
+        Self {
+            channel_frequency: rp.channel_frequency,
+            bandwidth: rp.bandwidth,
+            max_eirp: rp.max_eirp,
+            spreading: Some(rp.spreading.into()),
+        }
+    }
+}
+
+impl From<proto::BlockchainRegionParamV1> for RegionParam {
+    fn from(brp: proto::BlockchainRegionParamV1) -> Self {
+        Self {
+            channel_frequency: brp.channel_frequency,
+            bandwidth: brp.bandwidth,
+            max_eirp: brp.max_eirp,
+            spreading: brp.spreading.unwrap().into(),
+        }
+    }
+}
+
+impl From<BlockchainRegionSpreading> for proto::BlockchainRegionSpreadingV1 {
+    fn from(brs: BlockchainRegionSpreading) -> Self {
+        Self {
+            tagged_spreading: brs
+                .tagged_spreading
+                .into_iter()
+                .map(|ts| ts.into())
+                .collect(),
+        }
+    }
+}
+
+impl From<proto::BlockchainRegionSpreadingV1> for BlockchainRegionSpreading {
+    fn from(brs: proto::BlockchainRegionSpreadingV1) -> Self {
+        Self {
+            tagged_spreading: brs
+                .tagged_spreading
+                .into_iter()
+                .map(|ts| ts.into())
+                .collect(),
+        }
+    }
+}
+
+impl From<TaggedSpreading> for proto::TaggedSpreading {
+    fn from(ts: TaggedSpreading) -> Self {
+        Self {
+            region_spreading: ts.region_spreading.into(),
+            max_packet_size: ts.max_packet_size,
+        }
+    }
+}
+
+impl From<proto::TaggedSpreading> for TaggedSpreading {
+    fn from(ts: proto::TaggedSpreading) -> Self {
+        Self {
+            region_spreading: RegionSpreading::from_i32(ts.region_spreading).unwrap(),
+            max_packet_size: ts.max_packet_size,
+        }
+    }
+}
+
+impl RegionSpreading {
+    pub fn from_i32(v: i32) -> Result<Self> {
+        proto::RegionSpreading::from_i32(v)
+            .map(|rs| rs.into())
+            .ok_or_else(|| anyhow!("unsupported region spreading {v}"))
+    }
+}
+
+impl Serialize for RegionSpreading {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let a = proto::RegionSpreading::from(self);
+        serializer.serialize_str(&format!("{a}"))
+    }
+}
+
+impl<'de> Deserialize<'de> for RegionSpreading {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RegionSpreadingVisitor;
+
+        impl<'de> de::Visitor<'de> for RegionSpreadingVisitor {
+            type Value = RegionSpreading;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("region spreading string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<RegionSpreading, E>
+            where
+                E: de::Error,
+            {
+                let proto_region_spreading =
+                    proto::RegionSpreading::from_str(value).map_err(|_| {
+                        de::Error::custom(format!("unsupported region spreading: {value}"))
+                    })?;
+                Ok(proto_region_spreading.into())
+            }
+        }
+
+        deserializer.deserialize_str(RegionSpreadingVisitor)
+    }
+}
+
+impl From<RegionSpreading> for proto::RegionSpreading {
+    fn from(region: RegionSpreading) -> Self {
+        proto::RegionSpreading::from(&region)
+    }
+}
+
+impl From<&RegionSpreading> for proto::RegionSpreading {
+    fn from(sr: &RegionSpreading) -> Self {
+        match sr {
+            RegionSpreading::SfInvalid => proto::RegionSpreading::SfInvalid,
+            RegionSpreading::Sf7 => proto::RegionSpreading::Sf7,
+            RegionSpreading::Sf8 => proto::RegionSpreading::Sf8,
+            RegionSpreading::Sf9 => proto::RegionSpreading::Sf9,
+            RegionSpreading::Sf10 => proto::RegionSpreading::Sf10,
+            RegionSpreading::Sf11 => proto::RegionSpreading::Sf11,
+            RegionSpreading::Sf12 => proto::RegionSpreading::Sf12,
+        }
+    }
+}
+
+impl From<proto::RegionSpreading> for RegionSpreading {
+    fn from(rs: proto::RegionSpreading) -> Self {
+        match rs {
+            proto::RegionSpreading::SfInvalid => RegionSpreading::SfInvalid,
+            proto::RegionSpreading::Sf7 => RegionSpreading::Sf7,
+            proto::RegionSpreading::Sf8 => RegionSpreading::Sf8,
+            proto::RegionSpreading::Sf9 => RegionSpreading::Sf9,
+            proto::RegionSpreading::Sf10 => RegionSpreading::Sf10,
+            proto::RegionSpreading::Sf11 => RegionSpreading::Sf11,
+            proto::RegionSpreading::Sf12 => RegionSpreading::Sf12,
+        }
+    }
+}
+
+impl From<RegionSpreading> for i32 {
+    fn from(region: RegionSpreading) -> Self {
+        proto::RegionSpreading::from(region) as i32
+    }
+}

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,7 +1,7 @@
 use crate::{
     hex_field,
     server::{GwmpMap, Http, Server},
-    Result, OUI,
+    Oui, Result,
 };
 use helium_proto::services::iot_config::RouteV1 as ProtoRoute;
 use serde::{Deserialize, Serialize};
@@ -10,13 +10,13 @@ use serde::{Deserialize, Serialize};
 pub struct Route {
     pub id: String,
     pub net_id: hex_field::HexNetID,
-    pub oui: OUI,
+    pub oui: Oui,
     pub server: Server,
     pub max_copies: u32,
 }
 
 impl Route {
-    pub fn new(net_id: hex_field::HexNetID, oui: OUI, max_copies: u32) -> Self {
+    pub fn new(net_id: hex_field::HexNetID, oui: Oui, max_copies: u32) -> Self {
         Self {
             id: "".into(),
             net_id,


### PR DESCRIPTION
Dependent on <https://github.com/helium/proto/pull/276> being merged and updating the cli Cargo.toml dependency for the proto repo

Implements the cli command for generating and pushing region params records to the config service for loading the db. Accepts the region to populate data for as well as the path to a file defining the region's params in json format and an optional path to the h3 index list file for the region in question.