### PR TITLE
make idz file non-optional; default empty bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffbb2b8d00aa39d12669a551275448ecd1ca68f6407c0386dd8de0b35ece653"
+checksum = "e8350f592e44792e955658a58698ef9ce8312887ce517a7ef3b75c1d4c0211ff"
 dependencies = [
  "base64 0.21.0",
  "bs58",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#149997d2a74e08679e56c2c892d7e46f2d0d1c46"
+source = "git+https://github.com/helium/proto?branch=master#41c03318556157a7014ffd75d3fa6bb5ed7d3de5"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.87"
 clap = { version = "4.1.4", features = ["derive", "env"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
-helium-crypto = "0.6.3"
+helium-crypto = "0.6.6"
 dialoguer = "0.10.2"
 anyhow = "1.0.68"
 serde_test = "1.0.147"

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,12 +6,13 @@ use helium_crypto::{Keypair, PublicKey, Sign};
 use helium_proto::{
     services::iot_config::{
         gateway_client, org_client, route_client, session_key_filter_client, ActionV1,
-        LoadRegionReqV1, LoadRegionResV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgGetReqV1,
-        OrgListReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
-        RouteDeleteReqV1, RouteDevaddrRangesResV1, RouteEuisResV1, RouteGetDevaddrRangesReqV1,
-        RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1, RouteUpdateDevaddrRangesReqV1,
-        RouteUpdateEuisReqV1, RouteUpdateReqV1, SessionKeyFilterGetReqV1,
-        SessionKeyFilterListReqV1, SessionKeyFilterUpdateReqV1, SessionKeyFilterUpdateResV1,
+        GatewayLoadRegionReqV1, GatewayLoadRegionResV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1,
+        OrgGetReqV1, OrgListReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1,
+        RouteDeleteEuisReqV1, RouteDeleteReqV1, RouteDevaddrRangesResV1, RouteEuisResV1,
+        RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1,
+        RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
+        SessionKeyFilterGetReqV1, SessionKeyFilterListReqV1, SessionKeyFilterUpdateReqV1,
+        SessionKeyFilterUpdateResV1,
     },
     Message,
 };
@@ -429,10 +430,10 @@ impl GatewayClient {
         &mut self,
         region: Region,
         params: RegionParams,
-        indexes: Option<Vec<u8>>,
+        indexes: Vec<u8>,
         keypair: &Keypair,
-    ) -> Result<LoadRegionResV1> {
-        let mut request = LoadRegionReqV1 {
+    ) -> Result<GatewayLoadRegionResV1> {
+        let mut request = GatewayLoadRegionReqV1 {
             region: region.into(),
             params: Some(params.into()),
             hex_indexes: indexes,
@@ -481,4 +482,4 @@ impl_sign!(SessionKeyFilterGetReqV1, signature);
 impl_sign!(SessionKeyFilterUpdateReqV1, signature);
 impl_sign!(OrgCreateHeliumReqV1, signature);
 impl_sign!(OrgCreateRoamerReqV1, signature);
-impl_sign!(LoadRegionReqV1, signature);
+impl_sign!(GatewayLoadRegionReqV1, signature);

--- a/src/cmds/region_params.rs
+++ b/src/cmds/region_params.rs
@@ -20,9 +20,9 @@ pub async fn push_params(args: PushRegionParams) -> Result<Msg> {
             .read(&mut byte_buf)
             .context("reading index buffer")?;
 
-        Some(byte_buf)
+        byte_buf
     } else {
-        None
+        vec![]
     };
 
     if !args.commit {


### PR DESCRIPTION
Requires merging https://github.com/helium/proto/pull/284 first.
Renames the load region params req/res to conform to the convention used by the other iot_config rpc messages by prepending each message with the name of the service it corresponds with.
This makes the proto encoding of the `hex_indexes` field in the region loading rpc non-optional from the perspective of proto3 but still allows it to be an optional argument.
- [x] merge https://github.com/helium/proto/pull/284
- [x] update Cargo.toml to proto master branch again