### PR TITLE
Update client methods to send 'signer' field, enable create with delegates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jg/oracle-admin-keys#e6175e628530f3b3b44bbab2b7345a47e4e9b568"
+source = "git+https://github.com/helium/proto?branch=master#40388d260fd3603f453a965dbc13f79470b5adcb"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#4afcaaea25bde4e333f1e57fc32f163910e8ca0a"
+source = "git+https://github.com/helium/proto?branch=jg/oracle-admin-keys#e6175e628530f3b3b44bbab2b7345a47e4e9b568"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.87"
 clap = { version = "4.1.4", features = ["derive", "env"] }
-helium-proto = { git = "https://github.com/helium/proto", branch="jg/oracle-admin-keys", features=["services"]}
+helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = "0.6.6"
 dialoguer = "0.10.2"
 anyhow = "1.0.68"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.87"
 clap = { version = "4.1.4", features = ["derive", "env"] }
-helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
+helium-proto = { git = "https://github.com/helium/proto", branch="jg/oracle-admin-keys", features=["services"]}
 helium-crypto = "0.6.6"
 dialoguer = "0.10.2"
 anyhow = "1.0.68"

--- a/src/cmds/admin.rs
+++ b/src/cmds/admin.rs
@@ -10,7 +10,7 @@ use super::{AdminAddKey, AdminLoadRegionParams, AdminRemoveKey};
 
 pub async fn add_key(args: AdminAddKey) -> Result<Msg> {
     if args.commit {
-        let mut client = client::AdminClient::new(&args.config_host).await?;
+        let mut client = client::AdminClient::new(&args.config_host, &args.config_pubkey).await?;
         client
             .add_key(&args.pubkey, args.key_type, &args.keypair.to_keypair()?)
             .await?;
@@ -22,7 +22,7 @@ pub async fn add_key(args: AdminAddKey) -> Result<Msg> {
 
 pub async fn remove_key(args: AdminRemoveKey) -> Result<Msg> {
     if args.commit {
-        let mut client = client::AdminClient::new(&args.config_host).await?;
+        let mut client = client::AdminClient::new(&args.config_host, &args.config_pubkey).await?;
         client
             .remove_key(&args.pubkey, &args.keypair.to_keypair()?)
             .await?;
@@ -32,7 +32,7 @@ pub async fn remove_key(args: AdminRemoveKey) -> Result<Msg> {
 }
 
 pub async fn load_region(args: AdminLoadRegionParams) -> Result<Msg> {
-    let mut client = client::AdminClient::new(&args.config_host).await?;
+    let mut client = client::AdminClient::new(&args.config_host, &args.config_pubkey).await?;
     let params = RegionParams::from_file(&args.params_file)?;
 
     let index_bytes = if let Some(index_path) = &args.index_file {

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -16,6 +16,7 @@ pub mod route;
 pub mod session_key_filter;
 
 pub const ENV_CONFIG_HOST: &str = "HELIUM_CONFIG_HOST";
+pub const ENV_CONFIG_PUBKEY: &str = "HELIUM_CONFIG_PUBKEY";
 pub const ENV_KEYPAIR_BIN: &str = "HELIUM_KEYPAIR_BIN";
 pub const ENV_NET_ID: &str = "HELIUM_NET_ID";
 pub const ENV_OUI: &str = "HELIUM_OUI";
@@ -32,9 +33,17 @@ pub struct Cli {
         global = true,
         long,
         env = ENV_CONFIG_HOST,
-        default_value = "http://50.18.149.124:50051"
+        default_value = "http://mainnet-config.helium.io:6080"
     )]
     pub config_host: String,
+
+    #[arg(
+        global = true,
+        long,
+        env = ENV_CONFIG_PUBKEY,
+        default_value = "137oJzq1qZpSbzHawaysTGGsRCYTXG1MiTMQNxYSsQJp4YMDdN8"
+    )]
+    pub config_pubkey: String,
 
     #[arg(
         global = true,
@@ -137,6 +146,8 @@ pub struct ListRoutes {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -149,6 +160,8 @@ pub struct GetRoute {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -164,6 +177,8 @@ pub struct NewRoute {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -176,6 +191,8 @@ pub struct DeleteRoute {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -188,6 +205,8 @@ pub struct ActivateRoute {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -200,6 +219,8 @@ pub struct DeactivateRoute {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -233,6 +254,8 @@ pub struct UpdateMaxCopies {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -249,6 +272,8 @@ pub struct UpdateServer {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -272,6 +297,8 @@ pub struct UpdateHttp {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -284,6 +311,8 @@ pub struct UpdatePacketRouter {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -300,6 +329,8 @@ pub struct AddGwmpRegion {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -315,6 +346,8 @@ pub struct RemoveGwmpRegion {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -373,6 +406,8 @@ pub struct ListFilters {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -385,6 +420,8 @@ pub struct GetFilters {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -398,6 +435,8 @@ pub struct AddFilter {
     pub session_key: String,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(from_global)]
     pub keypair: PathBuf,
     /// Add EUI entry to a Route
@@ -417,6 +456,8 @@ pub struct RemoveFilter {
     #[arg(from_global)]
     pub config_host: String,
     #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(from_global)]
     pub keypair: PathBuf,
     /// Add EUI entry to a Route
     #[arg(short, long)]
@@ -431,6 +472,8 @@ pub struct ListEuis {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -443,6 +486,8 @@ pub struct AddEui {
     pub route_id: String,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(from_global)]
     pub keypair: PathBuf,
     /// Add EUI entry to a Route
@@ -461,6 +506,8 @@ pub struct RemoveEui {
     #[arg(from_global)]
     pub config_host: String,
     #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(from_global)]
     pub keypair: PathBuf,
     /// Remove EUI entry from the Route
     #[arg(short, long)]
@@ -475,6 +522,8 @@ pub struct ClearEuis {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     /// Remove ALL EUIs from a Route
     #[arg(short, long)]
     pub commit: bool,
@@ -488,6 +537,8 @@ pub struct ListDevaddrs {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -500,6 +551,8 @@ pub struct AddDevaddr {
     pub route_id: String,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(from_global)]
     pub keypair: PathBuf,
     /// Add Devaddr entry to a Route
@@ -518,6 +571,8 @@ pub struct RemoveDevaddr {
     #[arg(from_global)]
     pub config_host: String,
     #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(from_global)]
     pub keypair: PathBuf,
     /// Remove Devaddr entry from a Route
     #[arg(short, long)]
@@ -532,6 +587,8 @@ pub struct ClearDevaddrs {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     /// Remove ALL Devaddrs from a route
     #[arg(short, long)]
     pub commit: bool,
@@ -545,6 +602,8 @@ pub struct RouteSubnetMask {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -586,6 +645,8 @@ pub struct GenerateKeypair {
 pub struct ListOrgs {
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -594,6 +655,8 @@ pub struct GetOrg {
     pub oui: Oui,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
 }
 
 #[derive(Debug, Args)]
@@ -610,6 +673,8 @@ pub struct CreateHelium {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -628,6 +693,8 @@ pub struct CreateRoaming {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -654,6 +721,8 @@ pub struct AdminLoadRegionParams {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -667,6 +736,8 @@ pub struct AdminAddKey {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }
@@ -678,6 +749,8 @@ pub struct AdminRemoveKey {
     pub keypair: PathBuf,
     #[arg(from_global)]
     pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
     #[arg(long)]
     pub commit: bool,
 }

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    cmds::env::NetworkArg,
     hex_field::{self, HexNetID},
     region::Region,
     DevaddrConstraint, KeyType, Msg, Oui, PrettyJson, Result,
@@ -573,6 +574,9 @@ pub struct GenerateKeypair {
     #[arg(default_value = "./keypair.bin")]
     pub out_file: PathBuf,
 
+    /// The helium network for which to issue keys
+    #[arg(long, short, value_enum, default_value = "mainnet")]
+    pub network: NetworkArg,
     /// overwrite <out_file> if it already exists
     #[arg(long)]
     pub commit: bool,

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -603,6 +603,8 @@ pub struct CreateHelium {
     #[arg(long)]
     pub payer: PublicKey,
     #[arg(long)]
+    pub delegate: Option<Vec<PublicKey>>,
+    #[arg(long)]
     pub devaddr_count: u64,
     #[arg(from_global)]
     pub keypair: PathBuf,
@@ -618,6 +620,8 @@ pub struct CreateRoaming {
     pub owner: PublicKey,
     #[arg(long)]
     pub payer: PublicKey,
+    #[arg(long)]
+    pub delegate: Option<Vec<PublicKey>>,
     #[arg(long)]
     pub net_id: HexNetID,
     #[arg(from_global)]

--- a/src/cmds/org.rs
+++ b/src/cmds/org.rs
@@ -16,12 +16,18 @@ pub async fn get_org(args: GetOrg) -> Result<Msg> {
 }
 
 pub async fn create_helium_org(args: CreateHelium) -> Result<Msg> {
+    let delegates = if let Some(ref delegate_keys) = &args.delegate {
+        delegate_keys.to_vec()
+    } else {
+        vec![]
+    };
     if args.commit {
         let mut client = client::OrgClient::new(&args.config_host).await?;
         let org = client
             .create_helium(
                 &args.owner,
                 &args.payer,
+                delegates,
                 args.devaddr_count,
                 &args.keypair.to_keypair()?,
             )
@@ -35,12 +41,18 @@ pub async fn create_helium_org(args: CreateHelium) -> Result<Msg> {
 }
 
 pub async fn create_roaming_org(args: CreateRoaming) -> Result<Msg> {
+    let delegates = if let Some(ref delegate_keys) = &args.delegate {
+        delegate_keys.to_vec()
+    } else {
+        vec![]
+    };
     if args.commit {
         let mut client = client::OrgClient::new(&args.config_host).await?;
         let created_org = client
             .create_roamer(
                 &args.owner,
                 &args.payer,
+                delegates,
                 args.net_id.into(),
                 args.keypair.to_keypair()?,
             )

--- a/src/cmds/org.rs
+++ b/src/cmds/org.rs
@@ -2,14 +2,14 @@ use super::{CreateHelium, CreateRoaming, GetOrg, ListOrgs, PathBufKeypair, ENV_N
 use crate::{client, Msg, PrettyJson, Result};
 
 pub async fn list_orgs(args: ListOrgs) -> Result<Msg> {
-    let mut client = client::OrgClient::new(&args.config_host).await?;
+    let mut client = client::OrgClient::new(&args.config_host, &args.config_pubkey).await?;
     let org = client.list().await?;
 
     Msg::ok(org.pretty_json()?)
 }
 
 pub async fn get_org(args: GetOrg) -> Result<Msg> {
-    let mut client = client::OrgClient::new(&args.config_host).await?;
+    let mut client = client::OrgClient::new(&args.config_host, &args.config_pubkey).await?;
     let org = client.get(args.oui).await?;
 
     Msg::ok(org.pretty_json()?)
@@ -22,7 +22,7 @@ pub async fn create_helium_org(args: CreateHelium) -> Result<Msg> {
         vec![]
     };
     if args.commit {
-        let mut client = client::OrgClient::new(&args.config_host).await?;
+        let mut client = client::OrgClient::new(&args.config_host, &args.config_pubkey).await?;
         let org = client
             .create_helium(
                 &args.owner,
@@ -47,7 +47,7 @@ pub async fn create_roaming_org(args: CreateRoaming) -> Result<Msg> {
         vec![]
     };
     if args.commit {
-        let mut client = client::OrgClient::new(&args.config_host).await?;
+        let mut client = client::OrgClient::new(&args.config_host, &args.config_pubkey).await?;
         let created_org = client
             .create_roamer(
                 &args.owner,

--- a/src/cmds/route.rs
+++ b/src/cmds/route.rs
@@ -8,7 +8,7 @@ use super::{
 };
 
 pub async fn list_routes(args: ListRoutes) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     match client.list(args.oui, &args.keypair.to_keypair()?).await {
         Ok(route_list) => Msg::ok(route_list.pretty_json()?),
         Err(err) => Msg::err(format!("could not list routes: {err}")),
@@ -16,7 +16,7 @@ pub async fn list_routes(args: ListRoutes) -> Result<Msg> {
 }
 
 pub async fn get_route(args: GetRoute) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     match client
         .get(&args.route_id, &args.keypair.to_keypair()?)
         .await
@@ -27,7 +27,7 @@ pub async fn get_route(args: GetRoute) -> Result<Msg> {
 }
 
 pub async fn new_route(args: NewRoute) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let route = Route::new(args.net_id, args.oui, args.max_copies);
 
     if !args.commit {
@@ -48,7 +48,7 @@ pub async fn new_route(args: NewRoute) -> Result<Msg> {
 }
 
 pub async fn delete_route(args: DeleteRoute) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
 
     if !args.commit {
         return Msg::dry_run(format!("delete {}", args.route_id));
@@ -64,7 +64,7 @@ pub async fn delete_route(args: DeleteRoute) -> Result<Msg> {
 }
 
 pub async fn update_max_copies(args: UpdateMaxCopies) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -93,7 +93,7 @@ pub async fn update_max_copies(args: UpdateMaxCopies) -> Result<Msg> {
 }
 
 pub async fn update_server(args: UpdateServer) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -124,7 +124,7 @@ pub async fn update_server(args: UpdateServer) -> Result<Msg> {
 }
 
 pub async fn update_http(args: UpdateHttp) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -154,7 +154,7 @@ pub async fn update_http(args: UpdateHttp) -> Result<Msg> {
 }
 
 pub async fn add_gwmp_region(args: AddGwmpRegion) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -197,7 +197,7 @@ pub async fn add_gwmp_region(args: AddGwmpRegion) -> Result<Msg> {
 }
 
 pub async fn remove_gwmp_region(args: RemoveGwmpRegion) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -235,7 +235,7 @@ pub async fn remove_gwmp_region(args: RemoveGwmpRegion) -> Result<Msg> {
 }
 
 pub async fn update_packet_router(args: UpdatePacketRouter) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -265,7 +265,7 @@ pub async fn update_packet_router(args: UpdatePacketRouter) -> Result<Msg> {
 }
 
 pub async fn activate_route(args: ActivateRoute) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -294,7 +294,7 @@ pub async fn activate_route(args: ActivateRoute) -> Result<Msg> {
 }
 
 pub async fn deactivate_route(args: DeactivateRoute) -> Result<Msg> {
-    let mut client = client::RouteClient::new(&args.config_host).await?;
+    let mut client = client::RouteClient::new(&args.config_host, &args.config_pubkey).await?;
     let keypair = args.keypair.to_keypair()?;
 
     let mut route = client.get(&args.route_id, &keypair).await?;
@@ -330,7 +330,7 @@ pub mod euis {
     };
 
     pub async fn list_euis(args: ListEuis) -> Result<Msg> {
-        let mut client = client::EuiClient::new(&args.config_host).await?;
+        let mut client = client::EuiClient::new(&args.config_host, &args.config_pubkey).await?;
         let euis_for_route = client
             .get_euis(&args.route_id, &args.keypair.to_keypair()?)
             .await?;
@@ -339,7 +339,7 @@ pub mod euis {
     }
 
     pub async fn add_eui(args: AddEui) -> Result<Msg> {
-        let mut client = client::EuiClient::new(&args.config_host).await?;
+        let mut client = client::EuiClient::new(&args.config_host, &args.config_pubkey).await?;
         let eui_pair = Eui::new(args.route_id.clone(), args.app_eui, args.dev_eui)?;
 
         if !args.commit {
@@ -354,7 +354,7 @@ pub mod euis {
     }
 
     pub async fn remove_eui(args: RemoveEui) -> Result<Msg> {
-        let mut client = client::EuiClient::new(&args.config_host).await?;
+        let mut client = client::EuiClient::new(&args.config_host, &args.config_pubkey).await?;
         let eui_pair = Eui::new(args.route_id.clone(), args.app_eui, args.dev_eui)?;
 
         if !args.commit {
@@ -369,7 +369,7 @@ pub mod euis {
     }
 
     pub async fn clear_euis(args: ClearEuis) -> Result<Msg> {
-        let mut client = client::EuiClient::new(&args.config_host).await?;
+        let mut client = client::EuiClient::new(&args.config_host, &args.config_pubkey).await?;
 
         if !args.commit {
             return Msg::dry_run(format!("All Euis removed from {}", args.route_id));
@@ -393,7 +393,7 @@ pub mod devaddrs {
     };
 
     pub async fn list_devaddrs(args: ListDevaddrs) -> Result<Msg> {
-        let mut client = client::DevaddrClient::new(&args.config_host).await?;
+        let mut client = client::DevaddrClient::new(&args.config_host, &args.config_pubkey).await?;
         let devaddrs_for_route = client
             .get_devaddrs(&args.route_id, &args.keypair.to_keypair()?)
             .await?;
@@ -402,7 +402,7 @@ pub mod devaddrs {
     }
 
     pub async fn add_devaddr(args: AddDevaddr) -> Result<Msg> {
-        let mut client = client::DevaddrClient::new(&args.config_host).await?;
+        let mut client = client::DevaddrClient::new(&args.config_host, &args.config_pubkey).await?;
         let devaddr_range =
             DevaddrRange::new(args.route_id.clone(), args.start_addr, args.end_addr)?;
 
@@ -418,7 +418,7 @@ pub mod devaddrs {
     }
 
     pub async fn remove_devaddr(args: RemoveDevaddr) -> Result<Msg> {
-        let mut client = client::DevaddrClient::new(&args.config_host).await?;
+        let mut client = client::DevaddrClient::new(&args.config_host, &args.config_pubkey).await?;
         let devaddr_range =
             DevaddrRange::new(args.route_id.clone(), args.start_addr, args.end_addr)?;
 
@@ -434,7 +434,7 @@ pub mod devaddrs {
     }
 
     pub async fn clear_devaddrs(args: ClearDevaddrs) -> Result<Msg> {
-        let mut client = client::DevaddrClient::new(&args.config_host).await?;
+        let mut client = client::DevaddrClient::new(&args.config_host, &args.config_pubkey).await?;
 
         if !args.commit {
             return Msg::dry_run(format!("All Devadddrs removed from {}", args.route_id));
@@ -448,7 +448,7 @@ pub mod devaddrs {
     }
 
     pub async fn subnet_mask(args: RouteSubnetMask) -> Result<Msg> {
-        let mut client = client::DevaddrClient::new(&args.config_host).await?;
+        let mut client = client::DevaddrClient::new(&args.config_host, &args.config_pubkey).await?;
         let devaddrs_for_route: Vec<DevaddrSubnet> = client
             .get_devaddrs(&args.route_id, &args.keypair.to_keypair()?)
             .await?

--- a/src/cmds/session_key_filter.rs
+++ b/src/cmds/session_key_filter.rs
@@ -2,7 +2,7 @@ use super::{AddFilter, GetFilters, ListFilters, PathBufKeypair, RemoveFilter};
 use crate::{client, Msg, PrettyJson, Result, SessionKeyFilter};
 
 pub async fn list_filters(args: ListFilters) -> Result<Msg> {
-    let mut client = client::SkfClient::new(&args.config_host).await?;
+    let mut client = client::SkfClient::new(&args.config_host, &args.config_pubkey).await?;
     let filters = client
         .list_filters(args.oui, &args.keypair.to_keypair()?)
         .await?;
@@ -11,7 +11,7 @@ pub async fn list_filters(args: ListFilters) -> Result<Msg> {
 }
 
 pub async fn get_filters(args: GetFilters) -> Result<Msg> {
-    let mut client = client::SkfClient::new(&args.config_host).await?;
+    let mut client = client::SkfClient::new(&args.config_host, &args.config_pubkey).await?;
     let filters = client
         .get_filters(args.oui, args.devaddr, &args.keypair.to_keypair()?)
         .await?;
@@ -20,7 +20,7 @@ pub async fn get_filters(args: GetFilters) -> Result<Msg> {
 }
 
 pub async fn add_filter(args: AddFilter) -> Result<Msg> {
-    let mut client = client::SkfClient::new(&args.config_host).await?;
+    let mut client = client::SkfClient::new(&args.config_host, &args.config_pubkey).await?;
     let filter = SessionKeyFilter::new(args.oui, args.devaddr, args.session_key);
 
     if !args.commit {
@@ -35,7 +35,7 @@ pub async fn add_filter(args: AddFilter) -> Result<Msg> {
 }
 
 pub async fn remove_filter(args: RemoveFilter) -> Result<Msg> {
-    let mut client = client::SkfClient::new(&args.config_host).await?;
+    let mut client = client::SkfClient::new(&args.config_host, &args.config_pubkey).await?;
     let filter = SessionKeyFilter::new(args.oui, args.devaddr, args.session_key);
 
     if !args.commit {

--- a/src/region.rs
+++ b/src/region.rs
@@ -35,6 +35,7 @@ pub enum Region {
     As923_1d,
     As923_1e,
     As923_1f,
+    Unknown,
 }
 
 impl Region {
@@ -120,6 +121,7 @@ impl From<&Region> for ProtoRegion {
             Region::As923_1d => ProtoRegion::As9231d,
             Region::As923_1e => ProtoRegion::As9231e,
             Region::As923_1f => ProtoRegion::As9231f,
+            Region::Unknown => ProtoRegion::Unknown,
         }
     }
 }
@@ -155,6 +157,7 @@ impl From<ProtoRegion> for Region {
             ProtoRegion::As9231d => Region::As923_1d,
             ProtoRegion::As9231e => Region::As923_1e,
             ProtoRegion::As9231f => Region::As923_1f,
+            ProtoRegion::Unknown => Region::Unknown,
         }
     }
 }

--- a/src/region.rs
+++ b/src/region.rs
@@ -30,11 +30,11 @@ pub enum Region {
     Eu868F,
     Au915Sb1,
     Au915Sb2,
-    As9231a,
-    As9231c,
-    As9231d,
-    As9231e,
-    As9231f,
+    As923_1a,
+    As923_1c,
+    As923_1d,
+    As923_1e,
+    As923_1f,
 }
 
 impl Region {
@@ -115,11 +115,11 @@ impl From<&Region> for ProtoRegion {
             Region::Eu868F => ProtoRegion::Eu868F,
             Region::Au915Sb1 => ProtoRegion::Au915Sb1,
             Region::Au915Sb2 => ProtoRegion::Au915Sb2,
-            Region::As9231a => ProtoRegion::As9231a,
-            Region::As9231c => ProtoRegion::As9231c,
-            Region::As9231d => ProtoRegion::As9231d,
-            Region::As9231e => ProtoRegion::As9231e,
-            Region::As9231f => ProtoRegion::As9231f,
+            Region::As923_1a => ProtoRegion::As9231a,
+            Region::As923_1c => ProtoRegion::As9231c,
+            Region::As923_1d => ProtoRegion::As9231d,
+            Region::As923_1e => ProtoRegion::As9231e,
+            Region::As923_1f => ProtoRegion::As9231f,
         }
     }
 }
@@ -150,11 +150,11 @@ impl From<ProtoRegion> for Region {
             ProtoRegion::Eu868F => Region::Eu868F,
             ProtoRegion::Au915Sb1 => Region::Au915Sb1,
             ProtoRegion::Au915Sb2 => Region::Au915Sb2,
-            ProtoRegion::As9231a => Region::As9231a,
-            ProtoRegion::As9231c => Region::As9231c,
-            ProtoRegion::As9231d => Region::As9231d,
-            ProtoRegion::As9231e => Region::As9231e,
-            ProtoRegion::As9231f => Region::As9231f,
+            ProtoRegion::As9231a => Region::As923_1a,
+            ProtoRegion::As9231c => Region::As923_1c,
+            ProtoRegion::As9231d => Region::As923_1d,
+            ProtoRegion::As9231e => Region::As923_1e,
+            ProtoRegion::As9231f => Region::As923_1f,
         }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -27,6 +27,7 @@ pub const CONFIG_HOST: &str = "http://127.0.0.1:50051";
 
 pub fn generate_keypair(path: PathBuf) -> Result<PublicKey> {
     let out = cmds::env::generate_keypair(cmds::GenerateKeypair {
+        network: cmds::env::NetworkArg::Mainnet,
         out_file: path.clone(),
         commit: true,
     })?;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -11,6 +11,7 @@ use std::{path::PathBuf, str::FromStr};
 use tracing::info;
 
 pub const CONFIG_HOST: &str = "http://127.0.0.1:50051";
+pub const CONFIG_PUBKEY: &str = "config-server-signing-pubkey";
 
 /// These helpers use the CLI commands _and_ client methods directly.
 ///
@@ -49,12 +50,13 @@ pub async fn create_helium_org(
         devaddr_count,
         keypair: keypair_path,
         config_host: CONFIG_HOST.to_string(),
+        config_pubkey: CONFIG_PUBKEY.to_string(),
         commit: true,
     })
     .await?;
     info!("{out}");
 
-    let mut org_client = client::OrgClient::new(CONFIG_HOST).await?;
+    let mut org_client = client::OrgClient::new(CONFIG_HOST, CONFIG_PUBKEY).await?;
     let mut org_list = org_client.list().await?;
     // Put in creation order
     org_list.orgs.sort_by_key(|x| x.oui);
@@ -69,12 +71,13 @@ pub async fn ensure_no_routes(oui: u64, keypair_path: PathBuf) -> Result {
         oui,
         keypair: keypair_path.clone(),
         config_host: CONFIG_HOST.to_string(),
+        config_pubkey: CONFIG_PUBKEY.to_string(),
         commit: false,
     })
     .await?;
     info!("{out}");
 
-    let mut route_client = client::RouteClient::new(CONFIG_HOST).await?;
+    let mut route_client = client::RouteClient::new(CONFIG_HOST, CONFIG_PUBKEY).await?;
     let route_list = route_client.list(oui, &keypair_path.to_keypair()?).await?;
     assert!(route_list.routes.is_empty());
     Ok(())
@@ -91,12 +94,13 @@ pub async fn create_empty_route(
         max_copies: 5,
         keypair: keypair_path.clone(),
         config_host: CONFIG_HOST.to_string(),
+        config_pubkey: CONFIG_PUBKEY.to_string(),
         commit: true,
     })
     .await?;
     info!("{out1}");
 
-    let mut route_client = client::RouteClient::new(CONFIG_HOST).await?;
+    let mut route_client = client::RouteClient::new(CONFIG_HOST, CONFIG_PUBKEY).await?;
     let route_list = route_client.list(oui, &keypair_path.to_keypair()?).await?;
     Ok(route_list
         .routes
@@ -106,7 +110,7 @@ pub async fn create_empty_route(
 }
 
 pub async fn get_route(route_id: &str, keypair_path: PathBuf) -> Result<Route> {
-    let mut route_client = client::RouteClient::new(CONFIG_HOST).await?;
+    let mut route_client = client::RouteClient::new(CONFIG_HOST, CONFIG_PUBKEY).await?;
     let route = route_client
         .get(route_id, &keypair_path.to_keypair()?)
         .await?;
@@ -126,11 +130,12 @@ pub async fn ensure_num_euis(eui_count: usize, route_id: &str, keypair_path: Pat
         route_id: route_id.to_string(),
         keypair: keypair_path.clone(),
         config_host: CONFIG_HOST.to_string(),
+        config_pubkey: CONFIG_PUBKEY.to_string(),
     })
     .await?;
     info!("{out}");
 
-    let mut eui_client = client::EuiClient::new(CONFIG_HOST).await?;
+    let mut eui_client = client::EuiClient::new(CONFIG_HOST, CONFIG_PUBKEY).await?;
     let euis = eui_client
         .get_euis(route_id, &keypair_path.to_keypair()?)
         .await?;
@@ -147,11 +152,12 @@ pub async fn ensure_num_devaddrs(
         route_id: route_id.to_string(),
         keypair: keypair_path.clone(),
         config_host: CONFIG_HOST.to_string(),
+        config_pubkey: CONFIG_PUBKEY.to_string(),
     })
     .await?;
     info!("{out}");
 
-    let mut devaddr_client = client::DevaddrClient::new(CONFIG_HOST).await?;
+    let mut devaddr_client = client::DevaddrClient::new(CONFIG_HOST, CONFIG_PUBKEY).await?;
     let addrs = devaddr_client
         .get_devaddrs(route_id, &keypair_path.to_keypair()?)
         .await?;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -45,6 +45,7 @@ pub async fn create_helium_org(
     let out = cmds::org::create_helium_org(CreateHelium {
         owner: public_key.clone(),
         payer: public_key.clone(),
+        delegate: None,
         devaddr_count,
         keypair: keypair_path,
         config_host: CONFIG_HOST.to_string(),

--- a/tests/devaddrs.rs
+++ b/tests/devaddrs.rs
@@ -16,8 +16,9 @@ async fn create_route_and_add_remove_devaddrs() -> Result {
     let working_dir = TempDir::new()?;
     let keypair_path = working_dir.child("keypair.bin");
     let config_host = common::CONFIG_HOST.to_string();
+    let config_pubkey = common::CONFIG_PUBKEY.to_string();
 
-    let mut devaddr_client = client::DevaddrClient::new(&config_host).await?;
+    let mut devaddr_client = client::DevaddrClient::new(&config_host, &config_pubkey).await?;
 
     // Generate keypair
     let public_key = common::generate_keypair(keypair_path.clone())?;
@@ -38,6 +39,7 @@ async fn create_route_and_add_remove_devaddrs() -> Result {
         end_addr: hex_field::devaddr(2),
         route_id: route.id.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -52,6 +54,7 @@ async fn create_route_and_add_remove_devaddrs() -> Result {
         end_addr: devaddr_range.end_addr,
         route_id: route.id.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -64,6 +67,7 @@ async fn create_route_and_add_remove_devaddrs() -> Result {
         end_addr: devaddr_range.end_addr,
         route_id: route.id.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -90,6 +94,7 @@ async fn create_route_and_add_remove_devaddrs() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("4: {out4}");
@@ -98,6 +103,7 @@ async fn create_route_and_add_remove_devaddrs() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;

--- a/tests/euis.rs
+++ b/tests/euis.rs
@@ -15,6 +15,7 @@ async fn create_route_and_add_remove_euis() -> Result {
     let working_dir = TempDir::new()?;
     let keypair_path = working_dir.child("keypair.bin");
     let config_host = common::CONFIG_HOST.to_string();
+    let config_pubkey = common::CONFIG_PUBKEY.to_string();
 
     // Generate keypair
     let public_key = common::generate_keypair(keypair_path.clone())?;
@@ -34,6 +35,7 @@ async fn create_route_and_add_remove_euis() -> Result {
         app_eui: hex_field::eui(2),
         route_id: route.id.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -47,6 +49,7 @@ async fn create_route_and_add_remove_euis() -> Result {
         app_eui: hex_field::eui(2),
         route_id: route.id.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -55,7 +58,7 @@ async fn create_route_and_add_remove_euis() -> Result {
     common::ensure_no_euis(&route.id, keypair_path.clone()).await?;
 
     // Add many Euis to delete
-    let mut eui_client = client::EuiClient::new(common::CONFIG_HOST).await?;
+    let mut eui_client = client::EuiClient::new(common::CONFIG_HOST, common::CONFIG_PUBKEY).await?;
     let mut euis = vec![];
     for e in 0..15 {
         euis.push(Eui::new(

--- a/tests/protocols.rs
+++ b/tests/protocols.rs
@@ -15,6 +15,7 @@ async fn create_route_and_update_server() -> Result {
     let working_dir = TempDir::new()?;
     let keypair_path = working_dir.child("keypair.bin");
     let config_host = common::CONFIG_HOST.to_string();
+    let config_pubkey = common::CONFIG_PUBKEY.to_string();
 
     // Generate keypair
     let public_key = common::generate_keypair(keypair_path.clone())?;
@@ -30,6 +31,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("{out1}");
@@ -40,6 +42,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;
@@ -55,6 +58,7 @@ async fn create_route_and_update_server() -> Result {
         auth_header: Some("test-header".to_string()),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;
@@ -83,6 +87,7 @@ async fn create_route_and_update_server() -> Result {
         region_port: 9001,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;
@@ -101,6 +106,7 @@ async fn create_route_and_update_server() -> Result {
         region_port: 9002,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;
@@ -118,6 +124,7 @@ async fn create_route_and_update_server() -> Result {
         region: helium_config_service_cli::region::Region::As923_1a,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;

--- a/tests/protocols.rs
+++ b/tests/protocols.rs
@@ -79,7 +79,7 @@ async fn create_route_and_update_server() -> Result {
     // Set GWMP protocol
     let out4 = cmds::route::add_gwmp_region(AddGwmpRegion {
         route_id: route.id.clone(),
-        region: helium_config_service_cli::region::Region::As9231a,
+        region: helium_config_service_cli::region::Region::As923_1a,
         region_port: 9001,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
@@ -115,7 +115,7 @@ async fn create_route_and_update_server() -> Result {
 
     let out6 = cmds::route::remove_gwmp_region(RemoveGwmpRegion {
         route_id: route.id.clone(),
-        region: helium_config_service_cli::region::Region::As9231a,
+        region: helium_config_service_cli::region::Region::As923_1a,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
         commit: true,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -14,6 +14,7 @@ async fn create_route_and_update_server() -> Result {
     let working_dir = TempDir::new()?;
     let keypair_path = working_dir.child("keypair.bin");
     let config_host = common::CONFIG_HOST.to_string();
+    let config_pubkey = common::CONFIG_PUBKEY.to_string();
 
     // Generate keypair
     let public_key = common::generate_keypair(keypair_path.clone())?;
@@ -29,6 +30,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("{out1}");
@@ -42,6 +44,7 @@ async fn create_route_and_update_server() -> Result {
         port: 1337,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;

--- a/tests/skfs.rs
+++ b/tests/skfs.rs
@@ -16,8 +16,9 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
     let working_dir = TempDir::new()?;
     let keypair_path = working_dir.child("keypair.bin");
     let config_host = common::CONFIG_HOST.to_string();
+    let config_pubkey = common::CONFIG_PUBKEY.to_string();
 
-    let mut skf_client = client::SkfClient::new(&config_host).await?;
+    let mut skf_client = client::SkfClient::new(&config_host, &config_pubkey).await?;
 
     // Generate keypair
     let public_key = common::generate_keypair(keypair_path.clone())?;
@@ -31,6 +32,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         oui: org_res.org.oui,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("empty list: {out}");
@@ -45,6 +47,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         devaddr: hex_field::devaddr(1),
         session_key: "key-one".to_string(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -56,6 +59,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         devaddr: hex_field::devaddr(2),
         session_key: "key-two".to_string(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -67,6 +71,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         oui: org_res.org.oui,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("list of 2: {out}");
@@ -81,6 +86,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         devaddr: hex_field::devaddr(1),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("get, list of 1: {out}");
@@ -99,6 +105,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         devaddr: hex_field::devaddr(1),
         session_key: "key-one".to_string(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -110,6 +117,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         devaddr: hex_field::devaddr(2),
         session_key: "key-two".to_string(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         keypair: keypair_path.clone(),
         commit: true,
     })
@@ -121,6 +129,7 @@ async fn create_org_and_add_remove_session_key_filtesr() -> Result {
         oui: org_res.org.oui,
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("empty list: {out}");

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -14,6 +14,7 @@ async fn create_route_and_update_server() -> Result {
     let working_dir = TempDir::new()?;
     let keypair_path = working_dir.child("keypair.bin");
     let config_host = common::CONFIG_HOST.to_string();
+    let config_pubkey = common::CONFIG_PUBKEY.to_string();
 
     // Generate keypair
     let public_key = common::generate_keypair(keypair_path.clone())?;
@@ -29,6 +30,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
     })
     .await?;
     info!("{out}");
@@ -39,6 +41,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;
@@ -51,6 +54,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
+        config_pubkey: config_pubkey.clone(),
         commit: true,
     })
     .await?;


### PR DESCRIPTION
Updates the proto dependency to provide the required `signer` field for requests generated by converting the signing helium_crypto keypair to the binary of the public key.

Also enables creating orgs with delegate keys by repeating the `--delegate` long argument flag as many times as necessary at the `create-helium` and `create-roamer` commands, passing the b58 string encoding of the public keys to the flag.