### PR TITLE
allow enabling the org via cli in a pinch

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -8,12 +8,13 @@ use helium_proto::{
     services::iot_config::{
         admin_client, org_client, route_client, session_key_filter_client, ActionV1,
         AdminAddKeyReqV1, AdminKeyResV1, AdminLoadRegionReqV1, AdminLoadRegionResV1,
-        AdminRemoveKeyReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgGetReqV1, OrgListReqV1,
-        OrgListResV1, OrgResV1, RouteCreateReqV1, RouteDeleteReqV1, RouteDevaddrRangesResV1,
-        RouteEuisResV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1,
-        RouteListReqV1, RouteListResV1, RouteResV1, RouteUpdateDevaddrRangesReqV1,
-        RouteUpdateEuisReqV1, RouteUpdateReqV1, SessionKeyFilterGetReqV1,
-        SessionKeyFilterListReqV1, SessionKeyFilterUpdateReqV1, SessionKeyFilterUpdateResV1,
+        AdminRemoveKeyReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgEnableReqV1,
+        OrgEnableResV1, OrgGetReqV1, OrgListReqV1, OrgListResV1, OrgResV1, RouteCreateReqV1,
+        RouteDeleteReqV1, RouteDevaddrRangesResV1, RouteEuisResV1, RouteGetDevaddrRangesReqV1,
+        RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1, RouteListResV1, RouteResV1,
+        RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
+        SessionKeyFilterGetReqV1, SessionKeyFilterListReqV1, SessionKeyFilterUpdateReqV1,
+        SessionKeyFilterUpdateResV1,
     },
     Message,
 };
@@ -110,6 +111,19 @@ impl OrgClient {
         let response = self.client.create_roamer(request).await?.into_inner();
         response.verify(&self.server_pubkey)?;
         Ok(response.into())
+    }
+
+    pub async fn enable(&mut self, oui: u64, keypair: Keypair) -> Result<()> {
+        let mut request = OrgEnableReqV1 {
+            oui,
+            timestamp: current_timestamp()?,
+            signer: keypair.public_key().into(),
+            signature: vec![],
+        };
+        request.signature = request.sign(&keypair)?;
+        let response = self.client.enable(request).await?.into_inner();
+        response.verify(&self.server_pubkey)?;
+        Ok(())
     }
 }
 
@@ -578,6 +592,7 @@ impl_sign!(SessionKeyFilterGetReqV1, signature);
 impl_sign!(SessionKeyFilterUpdateReqV1, signature);
 impl_sign!(OrgCreateHeliumReqV1, signature);
 impl_sign!(OrgCreateRoamerReqV1, signature);
+impl_sign!(OrgEnableReqV1, signature);
 impl_sign!(AdminLoadRegionReqV1, signature);
 impl_sign!(AdminAddKeyReqV1, signature);
 impl_sign!(AdminRemoveKeyReqV1, signature);
@@ -606,6 +621,7 @@ macro_rules! impl_verify {
 
 impl_verify!(OrgListResV1, signature);
 impl_verify!(OrgResV1, signature);
+impl_verify!(OrgEnableResV1, signature);
 impl_verify!(RouteDevaddrRangesResV1, signature);
 impl_verify!(RouteEuisResV1, signature);
 impl_verify!(RouteListResV1, signature);

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -388,6 +388,8 @@ pub enum OrgCommands {
     CreateHelium(CreateHelium),
     /// Create a new Roaming Organization (admin only)
     CreateRoaming(CreateRoaming),
+    /// Enable a locked Oui
+    Enable(EnableOrg),
 }
 
 #[derive(Debug, Subcommand)]
@@ -689,6 +691,20 @@ pub struct CreateRoaming {
     pub delegate: Option<Vec<PublicKey>>,
     #[arg(long)]
     pub net_id: HexNetID,
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(long)]
+    pub commit: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct EnableOrg {
+    #[arg(long)]
+    pub oui: u64,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]

--- a/src/cmds/org.rs
+++ b/src/cmds/org.rs
@@ -1,4 +1,6 @@
-use super::{CreateHelium, CreateRoaming, GetOrg, ListOrgs, PathBufKeypair, ENV_NET_ID, ENV_OUI};
+use super::{
+    CreateHelium, CreateRoaming, EnableOrg, GetOrg, ListOrgs, PathBufKeypair, ENV_NET_ID, ENV_OUI,
+};
 use crate::{client, Msg, PrettyJson, Result};
 
 pub async fn list_orgs(args: ListOrgs) -> Result<Msg> {
@@ -69,4 +71,13 @@ pub async fn create_roaming_org(args: CreateRoaming) -> Result<Msg> {
         );
     }
     Msg::ok("pass `--commit` to create Roaming organization".to_string())
+}
+
+pub async fn enable_org(args: EnableOrg) -> Result<Msg> {
+    if args.commit {
+        let mut client = client::OrgClient::new(&args.config_host, &args.config_pubkey).await?;
+        client.enable(args.oui, args.keypair.to_keypair()?).await?;
+        return Msg::ok(format!("OUI {} enabled", args.oui));
+    }
+    Msg::ok(format!("pass `--commit` to enable OUI {}", args.oui))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use subnet::DevaddrConstraint;
 pub mod proto {
     pub use helium_proto::services::iot_config::{
         admin_add_key_req_v1::KeyTypeV1, DevaddrConstraintV1, DevaddrRangeV1, EuiPairV1,
-        OrgListResV1, OrgResV1, OrgV1, RouteListResV1, SessionKeyFilterV1,
+        OrgEnableResV1, OrgListResV1, OrgResV1, OrgV1, RouteListResV1, SessionKeyFilterV1,
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
             Org::Get(args) => org::get_org(args).await,
             Org::CreateHelium(args) => org::create_helium_org(args).await,
             Org::CreateRoaming(args) => org::create_roaming_org(args).await,
+            Org::Enable(args) => org::enable_org(args).await,
         },
         Commands::SessionKeyFilter { command } => match command {
             cmds::SessionKeyFilterCommands::List(args) => skf::list_filters(args).await,


### PR DESCRIPTION
enable unlocking an org manually when they have been disabled for low-DC balance but need to be unlocked faster than the standard oracle data cycle can process the request