### PR TITLE
gateway info command

### DIFF
--- a/src/cmds/gateway.rs
+++ b/src/cmds/gateway.rs
@@ -1,13 +1,15 @@
-use super::{GetLocation, PathBufKeypair};
-use crate::{client, Msg, PrettyJson, Result};
+use super::{GetHotspot, PathBufKeypair};
+use crate::{client, region::Region, Msg, PrettyJson, Result};
 use angry_purple_tiger::AnimalName;
 use h3ron::ToCoordinate;
 use helium_crypto::PublicKey;
-use helium_proto::services::iot_config::GatewayLocationResV1;
+use helium_proto::services::iot_config::{
+    GatewayInfo as GatewayInfoProto, GatewayLocationResV1, GatewayMetadata as GatewayMetadataProto,
+};
 use serde::Serialize;
 use std::str::FromStr;
 
-pub async fn location(args: GetLocation) -> Result<Msg> {
+pub async fn location(args: GetHotspot) -> Result<Msg> {
     let mut client = client::GatewayClient::new(&args.config_host, &args.config_pubkey).await?;
     match client
         .location(&args.hotspot, &args.keypair.to_keypair()?)
@@ -19,6 +21,20 @@ pub async fn location(args: GetLocation) -> Result<Msg> {
         }
         Err(err) => Msg::err(format!(
             "failed to retrieve {} location: {}",
+            &args.hotspot, err
+        )),
+    }
+}
+
+pub async fn info(args: GetHotspot) -> Result<Msg> {
+    let mut client = client::GatewayClient::new(&args.config_host, &args.config_pubkey).await?;
+    match client
+        .info(&args.hotspot, &args.keypair.to_keypair()?)
+        .await
+    {
+        Ok(info) => Msg::ok(info.pretty_json()?),
+        Err(err) => Msg::err(format!(
+            "failed to retrieve {} info: {}",
             &args.hotspot, err
         )),
     }
@@ -47,6 +63,63 @@ impl Location {
             hex,
             lat,
             lon,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct GatewayInfo {
+    name: String,
+    pubkey: PublicKey,
+    is_full_hotspot: bool,
+    metadata: Option<GatewayMetadata>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GatewayMetadata {
+    location: String,
+    lat: f64,
+    lon: f64,
+    region: Region,
+    gain: i32,
+    elevation: i32,
+}
+
+impl TryFrom<GatewayInfoProto> for GatewayInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(info: GatewayInfoProto) -> Result<Self, Self::Error> {
+        let pubkey = PublicKey::try_from(info.address)?;
+        let name: AnimalName = pubkey.clone().into();
+        let metadata = if let Some(md) = info.metadata {
+            Some(md.try_into()?)
+        } else {
+            None
+        };
+        Ok(Self {
+            name: name.to_string(),
+            pubkey,
+            is_full_hotspot: info.is_full_hotspot,
+            metadata,
+        })
+    }
+}
+
+impl TryFrom<GatewayMetadataProto> for GatewayMetadata {
+    type Error = h3ron::Error;
+
+    fn try_from(md: GatewayMetadataProto) -> Result<Self, Self::Error> {
+        let location = md.clone().location;
+        let (lat, lon) = h3ron::H3Cell::from_str(&md.location)?
+            .to_coordinate()?
+            .x_y();
+        Ok(Self {
+            location,
+            lat,
+            lon,
+            region: md.region().into(),
+            gain: md.gain,
+            elevation: md.elevation,
         })
     }
 }

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -102,7 +102,9 @@ pub enum EnvCommands {
 #[derive(Debug, Subcommand)]
 pub enum GatewayCommands {
     /// Retrieve H3 index location for the given hotspot
-    Location(GetLocation),
+    Location(GetHotspot),
+    /// Retrieve the on-chain registered info for the hotspot
+    Info(GetHotspot),
 }
 
 #[derive(Debug, Subcommand)]
@@ -148,7 +150,7 @@ pub enum RouteCommands {
 }
 
 #[derive(Debug, Args)]
-pub struct GetLocation {
+pub struct GetHotspot {
     #[arg(long)]
     pub hotspot: PublicKey,
     #[arg(from_global)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ impl Display for Msg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Msg::DryRun(msg) => write!(f, "== DRY RUN == (pass `--commit`)\n{msg}"),
-            Msg::Success(msg) => write!(f, "\u{2713} {msg}"),
+            Msg::Success(msg) => write!(f, "{msg}"),
             Msg::Error(msg) => write!(f, "\u{2717} {msg}"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
         },
         Commands::Gateway { command } => match command {
             cmds::GatewayCommands::Location(args) => gateway::location(args).await,
+            cmds::GatewayCommands::Info(args) => gateway::info(args).await,
         },
     }
 }


### PR DESCRIPTION
allow retrieving gateway info, including all on-chain registered information
additionally, removes the "check mark" unicode character sequence from the print output on successful messages to allow for parsing the resulting json