### PR TITLE
Organization update commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#fffe87406377e8e143739cf16685d230aa7f4cba"
+source = "git+https://github.com/helium/proto?branch=jg/org-update#36686201566640858b25e606ed5870ede11741cb"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jg/org-update#1eebf307d0e52edcc279692fae174ae0448e29d2"
+source = "git+https://github.com/helium/proto?branch=master#a96075ee01deb7e89b3254733ccb8ad0d68d7dd8"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jg/org-update#36686201566640858b25e606ed5870ede11741cb"
+source = "git+https://github.com/helium/proto?branch=jg/org-update#1eebf307d0e52edcc279692fae174ae0448e29d2"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ dialoguer = "0.10.2"
 clap = { version = "4.2.7", features = ["derive", "env"] }
 futures = "0.3.28"
 helium-crypto = "0.6.9"
-helium-proto = { git = "https://github.com/helium/proto", branch="jg/org-update", features=["services"]}
+helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 h3ron = "0.17.0"
 ipnet = "2.7.2"
 prost = "0.11.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ dialoguer = "0.10.2"
 clap = { version = "4.2.7", features = ["derive", "env"] }
 futures = "0.3.28"
 helium-crypto = "0.6.9"
-helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
+helium-proto = { git = "https://github.com/helium/proto", branch="jg/org-update", features=["services"]}
 h3ron = "0.17.0"
 ipnet = "2.7.2"
 prost = "0.11.9"

--- a/src/cmds/admin.rs
+++ b/src/cmds/admin.rs
@@ -1,4 +1,4 @@
-use crate::{client, cmds::PathBufKeypair, region_params::RegionParams, Msg, PrettyJson, Result};
+use crate::{client, cmds::PathBufKeypair, region_params::RegionParams, Msg, Result};
 use anyhow::Context;
 use helium_proto::Region as ProtoRegion;
 use std::{
@@ -49,7 +49,10 @@ pub async fn load_region(args: AdminLoadRegionParams) -> Result<Msg> {
     };
 
     if !args.commit {
-        return Msg::dry_run(params.pretty_json()?);
+        return Msg::dry_run(format!(
+            "params loaded for region {}",
+            ProtoRegion::from(args.region)
+        ));
     }
 
     match client
@@ -62,9 +65,8 @@ pub async fn load_region(args: AdminLoadRegionParams) -> Result<Msg> {
         .await
     {
         Ok(_) => Msg::ok(format!(
-            "created region params {}\n{}",
-            ProtoRegion::from(args.region),
-            params.pretty_json()?
+            "params loaded for region {}",
+            ProtoRegion::from(args.region)
         )),
         Err(err) => Msg::err(format!("region params not created: {err}")),
     }

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     cmds::env::NetworkArg,
     hex_field::{self, HexNetID},
     region::Region,
-    DevaddrConstraint, KeyType, Msg, Oui, PrettyJson, Result,
+    DevaddrConstraint, HeliumNetId, KeyType, Msg, Oui, PrettyJson, Result,
 };
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
@@ -431,6 +431,11 @@ pub enum OrgCommands {
     CreateRoaming(CreateRoaming),
     /// Enable a locked Oui
     Enable(EnableOrg),
+    /// Update Org record
+    Update {
+        #[command(subcommand)]
+        command: OrgUpdateCommand,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -721,6 +726,8 @@ pub struct CreateHelium {
     pub delegate: Option<Vec<PublicKey>>,
     #[arg(long)]
     pub devaddr_count: u64,
+    #[arg(long, value_enum)]
+    pub net_id: HeliumNetId,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]
@@ -741,6 +748,74 @@ pub struct CreateRoaming {
     pub delegate: Option<Vec<PublicKey>>,
     #[arg(long)]
     pub net_id: HexNetID,
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(long)]
+    pub commit: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum OrgUpdateCommand {
+    /// Update the org owner pubkey
+    Owner(OrgUpdateKey),
+    /// Update the org payer pubkey
+    Payer(OrgUpdateKey),
+    /// Add delegate key to org
+    DelegateAdd(OrgUpdateKey),
+    /// Remove delegate key from org
+    DelegateRemove(OrgUpdateKey),
+    /// Add devaddr constraint to org
+    DevaddrConstraintAdd(DevaddrUpdateConstraint),
+    /// Remove devaddr constraint from org
+    DevaddrConstraintRemove(DevaddrUpdateConstraint),
+    /// Add an even-numbered Devaddr slab to org
+    DevaddrAddSlab(DevaddrAddSlab),
+}
+
+#[derive(Debug, Args)]
+pub struct OrgUpdateKey {
+    #[arg(long, short)]
+    pub oui: u64,
+    #[arg(long, short)]
+    pub pubkey: PublicKey,
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(long)]
+    pub commit: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DevaddrAddSlab {
+    #[arg(long, short)]
+    pub oui: u64,
+    #[arg(long, short)]
+    pub devaddr_count: u64,
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(long)]
+    pub commit: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DevaddrUpdateConstraint {
+    #[arg(long, short)]
+    pub oui: u64,
+    #[arg(short, long, value_parser = hex_field::validate_devaddr)]
+    pub start_addr: hex_field::HexDevAddr,
+    #[arg(short, long, value_parser = hex_field::validate_devaddr)]
+    pub end_addr: hex_field::HexDevAddr,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -773,7 +773,7 @@ pub enum OrgUpdateCommand {
     /// Remove devaddr constraint from org
     DevaddrConstraintRemove(DevaddrUpdateConstraint),
     /// Add an even-numbered Devaddr slab to org
-    DevaddrAddSlab(DevaddrAddSlab),
+    DevaddrSlabAdd(DevaddrSlabAdd),
 }
 
 #[derive(Debug, Args)]
@@ -793,7 +793,7 @@ pub struct OrgUpdateKey {
 }
 
 #[derive(Debug, Args)]
-pub struct DevaddrAddSlab {
+pub struct DevaddrSlabAdd {
     #[arg(long, short)]
     pub oui: u64,
     #[arg(long, short)]

--- a/src/cmds/org.rs
+++ b/src/cmds/org.rs
@@ -1,5 +1,5 @@
 use super::{
-    CreateHelium, CreateRoaming, DevaddrAddSlab, DevaddrUpdateConstraint, EnableOrg, GetOrg,
+    CreateHelium, CreateRoaming, DevaddrSlabAdd, DevaddrUpdateConstraint, EnableOrg, GetOrg,
     ListOrgs, OrgUpdateKey, PathBufKeypair, ENV_NET_ID, ENV_OUI,
 };
 use crate::{client, subnet::DevaddrConstraint, Msg, PrettyJson, Result};
@@ -170,7 +170,7 @@ pub async fn remove_delegate_key(args: OrgUpdateKey) -> Result<Msg> {
     ))
 }
 
-pub async fn add_devaddr_slab(args: DevaddrAddSlab) -> Result<Msg> {
+pub async fn add_devaddr_slab(args: DevaddrSlabAdd) -> Result<Msg> {
     if args.commit {
         let mut client = client::OrgClient::new(&args.config_host, &args.config_pubkey).await?;
         let updated_org = client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,10 @@ use subnet::DevaddrConstraint;
 
 pub mod proto {
     pub use helium_proto::services::iot_config::{
-        admin_add_key_req_v1::KeyTypeV1, route_skf_update_req_v1::RouteSkfUpdateV1, ActionV1,
-        DevaddrConstraintV1, DevaddrRangeV1, EuiPairV1, GatewayLocationResV1, OrgEnableResV1,
-        OrgListResV1, OrgResV1, OrgV1, RouteListResV1, SkfV1,
+        admin_add_key_req_v1::KeyTypeV1, org_create_helium_req_v1::HeliumNetId,
+        route_skf_update_req_v1::RouteSkfUpdateV1, ActionV1, DevaddrConstraintV1, DevaddrRangeV1,
+        EuiPairV1, GatewayLocationResV1, OrgEnableResV1, OrgListResV1, OrgResV1, OrgV1,
+        RouteListResV1, SkfV1,
     };
 }
 
@@ -76,6 +77,26 @@ impl<S: ?Sized + serde::Serialize> PrettyJson for S {
 
     fn pretty_json(&self) -> Result<String> {
         serde_json::to_string_pretty(&self).map_err(|e| e.into())
+    }
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum HeliumNetId {
+    #[value(alias("0x00003c"))]
+    Type0_0x00003c,
+    #[value(alias("0x60002d"))]
+    Type3_0x60002d,
+    #[value(alias("0xc00053"))]
+    Type6_0xc00053,
+}
+
+impl From<HeliumNetId> for proto::HeliumNetId {
+    fn from(id: HeliumNetId) -> Self {
+        match id {
+            HeliumNetId::Type0_0x00003c => proto::HeliumNetId::Type00x00003c,
+            HeliumNetId::Type3_0x60002d => proto::HeliumNetId::Type30x60002d,
+            HeliumNetId::Type6_0xc00053 => proto::HeliumNetId::Type60xc00053,
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
                 cmds::OrgUpdateCommand::DelegateRemove(args) => {
                     org::remove_delegate_key(args).await
                 }
-                cmds::OrgUpdateCommand::DevaddrAddSlab(args) => org::add_devaddr_slab(args).await,
+                cmds::OrgUpdateCommand::DevaddrSlabAdd(args) => org::add_devaddr_slab(args).await,
                 cmds::OrgUpdateCommand::DevaddrConstraintAdd(args) => {
                     org::add_devaddr_constraint(args).await
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,21 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
             Org::CreateHelium(args) => org::create_helium_org(args).await,
             Org::CreateRoaming(args) => org::create_roaming_org(args).await,
             Org::Enable(args) => org::enable_org(args).await,
+            Org::Update { command } => match command {
+                cmds::OrgUpdateCommand::Owner(args) => org::update_owner(args).await,
+                cmds::OrgUpdateCommand::Payer(args) => org::update_payer(args).await,
+                cmds::OrgUpdateCommand::DelegateAdd(args) => org::add_delegate_key(args).await,
+                cmds::OrgUpdateCommand::DelegateRemove(args) => {
+                    org::remove_delegate_key(args).await
+                }
+                cmds::OrgUpdateCommand::DevaddrAddSlab(args) => org::add_devaddr_slab(args).await,
+                cmds::OrgUpdateCommand::DevaddrConstraintAdd(args) => {
+                    org::add_devaddr_constraint(args).await
+                }
+                cmds::OrgUpdateCommand::DevaddrConstraintRemove(args) => {
+                    org::remove_devaddr_constraint(args).await
+                }
+            },
         },
         Commands::SubnetMask(args) => cmds::subnet_mask(args),
         Commands::Admin { command } => match command {

--- a/src/server.rs
+++ b/src/server.rs
@@ -335,13 +335,14 @@ mod tests {
             dedupe_timeout: 777,
             path: "/fns".into(),
             auth_header: "auth-header".to_string(),
+            receiver_nsid: "".to_string(),
         });
         assert_ser_tokens(
             &http,
             &[
                 Token::Struct {
                     name: "Http",
-                    len: 5,
+                    len: 6,
                 },
                 Token::Str("type"),
                 Token::Str("http"),
@@ -356,6 +357,8 @@ mod tests {
                 Token::Str("/fns"),
                 Token::Str("auth_header"),
                 Token::Str("auth-header"),
+                Token::Str("receiver_nsid"),
+                Token::Str(""),
                 Token::StructEnd,
             ],
         );

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,7 +4,7 @@ use helium_config_service_cli::{
     cmds::{self, *},
     hex_field,
     route::Route,
-    OrgResponse, Result,
+    HeliumNetId, OrgResponse, Result,
 };
 use helium_crypto::PublicKey;
 use std::{path::PathBuf, str::FromStr};
@@ -48,6 +48,7 @@ pub async fn create_helium_org(
         payer: public_key.clone(),
         delegate: None,
         devaddr_count,
+        net_id: HeliumNetId::Type0_0x00003c,
         keypair: keypair_path,
         config_host: CONFIG_HOST.to_string(),
         config_pubkey: CONFIG_PUBKEY.to_string(),

--- a/tests/protocols.rs
+++ b/tests/protocols.rs
@@ -55,6 +55,7 @@ async fn create_route_and_update_server() -> Result {
         route_id: route.id.clone(),
         dedupe_timeout: 234,
         path: "path".to_string(),
+        receiver_nsid: None,
         auth_header: Some("test-header".to_string()),
         keypair: keypair_path.clone(),
         config_host: config_host.clone(),
@@ -75,7 +76,8 @@ async fn create_route_and_update_server() -> Result {
             flow_type: server::FlowType::Async,
             dedupe_timeout: 234,
             path: "path".to_string(),
-            auth_header: "test-header".to_string()
+            auth_header: "test-header".to_string(),
+            receiver_nsid: "".to_string(),
         },
         http_protocol
     );


### PR DESCRIPTION
- [x] depends on https://github.com/helium/proto/pull/326

Adds commands necessary to perform modifications on existing organization records. Includes:
- adding and removing delegate keys
- updating the owner pubkey
- updating the payer pubkey
- adding and removing devaddr constraint ranges
- adding a block of additional devaddr ranges