### PR TITLE
update default config service url to the https endpoint

### DIFF
--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -33,7 +33,7 @@ pub struct Cli {
         global = true,
         long,
         env = ENV_CONFIG_HOST,
-        default_value = "http://mainnet-config.helium.io:6080"
+        default_value = "https://config.iot.mainnet.helium.io:6080"
     )]
     pub config_host: String,
 


### PR DESCRIPTION
default the config cli to connect to the https endpoint of the production config service