### PR TITLE
set routes' ignore empty skf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#91cd0c3953e8e233a86e6c67120a6df9b9b1cb40"
+source = "git+https://github.com/helium/proto?branch=master#c10a73fc89d895f439bc82efbbc8cd11ed880546"
 dependencies = [
  "bytes",
  "prost",

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -265,6 +265,8 @@ pub enum RouteUpdateCommand {
     RemoveGwmpRegion(RemoveGwmpRegion),
     /// Set the Route Protocol to PacketRouter (GRPC)
     PacketRouter(UpdatePacketRouter),
+    /// Set route `ignore_empty_skf` boolean
+    IgnoreEmptySkf(SetIgnoreEmptySkf),
 }
 
 #[derive(Debug, Args)]
@@ -368,6 +370,22 @@ pub struct RemoveGwmpRegion {
     #[arg(value_enum)]
     pub region: Region,
 
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
+    #[arg(long)]
+    pub commit: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SetIgnoreEmptySkf {
+    #[arg(short, long)]
+    pub route_id: String,
+    #[arg(short, long)]
+    pub ignore: bool,
     #[arg(from_global)]
     pub keypair: PathBuf,
     #[arg(from_global)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,9 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
                 RouteUpdateCommand::AddGwmpRegion(args) => route::add_gwmp_region(args).await,
                 RouteUpdateCommand::RemoveGwmpRegion(args) => route::remove_gwmp_region(args).await,
                 RouteUpdateCommand::PacketRouter(args) => route::update_packet_router(args).await,
+                RouteUpdateCommand::IgnoreEmptySkf(args) => {
+                    route::update_ignore_empty_skf(args).await
+                }
             },
             RouteCommands::Euis { command } => match command {
                 cmds::EuiCommands::List(args) => euis::list_euis(args).await,

--- a/src/route.rs
+++ b/src/route.rs
@@ -15,6 +15,7 @@ pub struct Route {
     pub max_copies: u32,
     pub active: bool,
     pub locked: bool,
+    pub ignore_empty_skf: bool,
 }
 
 impl Route {
@@ -27,6 +28,7 @@ impl Route {
             max_copies,
             locked: false,
             active: true,
+            ignore_empty_skf: false,
         }
     }
 
@@ -41,6 +43,10 @@ impl Route {
     pub fn http_update(&mut self, http: Http) -> Result {
         self.server.http_update(http)
     }
+
+    pub fn set_ignore_empty_skf(&mut self, ignore: bool) {
+        self.ignore_empty_skf = ignore;
+    }
 }
 
 impl From<ProtoRoute> for Route {
@@ -53,6 +59,7 @@ impl From<ProtoRoute> for Route {
             max_copies: route.max_copies,
             locked: route.locked,
             active: route.active,
+            ignore_empty_skf: route.ignore_empty_skf,
         }
     }
 }
@@ -67,6 +74,7 @@ impl From<Route> for ProtoRoute {
             max_copies: route.max_copies,
             locked: route.locked,
             active: route.active,
+            ignore_empty_skf: route.ignore_empty_skf,
         }
     }
 }
@@ -88,6 +96,7 @@ mod tests {
             max_copies: 999,
             locked: true,
             active: true,
+            ignore_empty_skf: false,
         };
 
         let v1 = RouteV1 {
@@ -102,6 +111,7 @@ mod tests {
             max_copies: 999,
             locked: true,
             active: true,
+            ignore_empty_skf: false,
         };
         assert_eq!(route, Route::from(v1.clone()));
         assert_eq!(v1, RouteV1::from(route));


### PR DESCRIPTION
allow setting the `ignore_empty_skf` boolean setting of a route via the cli per https://github.com/helium/proto/pull/337