### PR TITLE
Derive CLI version from git tags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+
+    let version = std::process::Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| {
+            let s = s.trim();
+            s.strip_prefix('v').unwrap_or(s).to_string()
+        })
+        .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap());
+
+    println!("cargo:rustc-env=GIT_VERSION={version}");
+}

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -25,7 +25,7 @@ pub const ENV_MAX_COPIES: &str = "HELIUM_MAX_COPIES";
 
 #[derive(Debug, Parser)]
 #[command(name = "helium-config-cli")]
-#[command(author, version, about, long_about=None)]
+#[command(author, version = env!("GIT_VERSION"), about, long_about=None)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,


### PR DESCRIPTION
## Summary
- Add `build.rs` that runs `git describe --tags` at compile time to set `GIT_VERSION`
- Update clap `#[command]` to use `env!("GIT_VERSION")` instead of `CARGO_PKG_VERSION`
- Includes `rerun-if-changed` directives so the build script only re-runs when HEAD or tags change

The CLI was hardcoded to report `0.1.0` from `Cargo.toml` regardless of which tagged release was built. Now it automatically reflects the git tag (e.g. `0.2.3`, or `0.2.3-5-gabcdef` for dev builds).

## Test plan
- [x] `cargo run -- --version` reports version matching latest git tag — confirmed: `0.2.3-1-g5950f82`
- [x] Building on a tagged commit shows the clean version (e.g. `0.2.3`) — confirmed: `99.0.0-test` with temp tag
- [x] Building after the tag shows distance (e.g. `0.2.3-1-gabcdef`) — confirmed: `0.2.3-1-g5950f82`
- [x] Building without git falls back to `Cargo.toml` version — confirmed: `0.1.0` with git stubbed out